### PR TITLE
Allow setting 'zone_id' variable instead of doing the `terraform import`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,11 +70,13 @@ resource "mailgun_domain" "this" {
 }
 
 data "aws_route53_zone" "selected" {
+  # if this module created/manages the zone, then refer to its zone_id, otherwise
+  # refer to the zone_id passed into this module
   zone_id = "${var.zone_id == "0" ? "${element(concat(aws_route53_zone.this.*.zone_id, list("")), 0) }" : var.zone_id}"
 }
 
 resource "aws_route53_zone" "this" {
-  # If zone_id is its default (0) then dont create a zone
+  # If zone_id is its default (0) then create a new zone, else, use zone_id passed in
   count = "${var.zone_id == "0" ? 1 : 0}"
   # This hack deals with https://github.com/hashicorp/terraform/issues/8511
   name          = "${element( split("","${var.domain}"), "${ length("${var.domain}") -1 }") == "." ? var.domain : "${var.domain}."}"

--- a/main.tf
+++ b/main.tf
@@ -3,20 +3,42 @@
  *
  * This template creates the following resources
  *   - A Mailgun domain
- *   - An AWS Route53 Zone
+ *   - An AWS Route53 Zone (unless the zone_id variable is set)
  *   - AWS Route53 Records:
  *     - SPF, DKIM, CNAME, MX
  *
  * The MX records are optional, to disable set the variable mailgun_set_mx_for_inbound to false.
  *
- * If using an existing Route53 Zone, perform a terraform import on your zone:
+ * If using an existing Route53 Zone, you must set the 'zone_id' terraform variable for this module.
  *
- * $ terraform import module.my_instance.aws_route53_zone.this <your_route53_zone_id>
+ * Another option is to import your Route53 zone *into* this module, but that is probably not the
+ * "route" you want to go. (see what I did there?) But if you do:
  *
- * where the 'my_instance' portion is the name you choose:
+ * $ terraform import module.mailer.aws_route53_zone.this[0] <your_route53_zone_id>
  *
- * module "my_instance" {
+ * (The `[0]` is needed becauser it is a "conditional resource" and you must refer to the 'count'
+ *  index when importing, which is always [0])
+ *
+ * where the 'mailer' portion is the name you choose:
+ *
+ * module "mailer" {
  *   source = "github.com/samstav/terraform-mailgun-aws"
+ * }
+ *
+ * # In *either* case, you can refer to your zone id like this:
+ *
+ *   "${module.mailer.zone_id}"
+ *
+ * Since 'zone_id' is also an output variable from the terraform-mailgun-aws module.
+ *
+ * Here is an example of how one might use the 'zone_id' output variable:
+ *
+ * resource "aws_route53_record" "keybase_proof" {
+ *   zone_id = "${module.mailer.zone_id}"
+ *   name = "_keybase"
+ *   type = "TXT"
+ *   ttl = 300
+ *   records = ["keybase-site-verification=JHEIDMF-NkenDk389DnekD83ls8KLDjenf88slej89"]
  * }
  *
  */

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,10 @@ resource "mailgun_domain" "this" {
 
 }
 
+data "aws_route53_zone" "selected" {
+  zone_id = "${var.zone_id == "0" ? "${element(concat(aws_route53_zone.this.*.zone_id, list("")), 0) }" : var.zone_id}"
+}
+
 resource "aws_route53_zone" "this" {
   # If zone_id is its default (0) then dont create a zone
   count = "${var.zone_id == "0" ? 1 : 0}"
@@ -57,15 +61,16 @@ resource "aws_route53_zone" "this" {
 }
 
 resource "aws_route53_record" "mailgun_sending_record_0" {
-  zone_id = "${aws_route53_zone.this.zone_id}"
+  zone_id = "${data.aws_route53_zone.selected.zone_id}"
   name    = "${mailgun_domain.this.sending_records.0.name}."
   ttl     = "${var.record_ttl}"
   type    = "${mailgun_domain.this.sending_records.0.record_type}"
   records = ["${mailgun_domain.this.sending_records.0.value}"]
 }
 
+
 resource "aws_route53_record" "mailgun_sending_record_1" {
-  zone_id = "${aws_route53_zone.this.zone_id}"
+  zone_id = "${data.aws_route53_zone.selected.zone_id}"
   name    = "${mailgun_domain.this.sending_records.1.name}."
   ttl     = "${var.record_ttl}"
   type    = "${mailgun_domain.this.sending_records.1.record_type}"
@@ -73,7 +78,7 @@ resource "aws_route53_record" "mailgun_sending_record_1" {
 }
 
 resource "aws_route53_record" "mailgun_sending_record_2" {
-  zone_id = "${aws_route53_zone.this.zone_id}"
+  zone_id = "${data.aws_route53_zone.selected.zone_id}"
   name    = "${mailgun_domain.this.sending_records.2.name}."
   ttl     = "${var.record_ttl}"
   type    = "${mailgun_domain.this.sending_records.2.record_type}"
@@ -85,7 +90,7 @@ resource "aws_route53_record" "mailgun_receiving_records_mx" {
   # mail and just want their domain verified and setup for outbound
   # Use the count trick to make this optional.
   count = "${var.mailgun_set_mx_for_inbound ? 1 : 0}"
-  zone_id = "${aws_route53_zone.this.zone_id}"
+  zone_id = "${data.aws_route53_zone.selected.zone_id}"
   name = ""
   ttl     = "${var.record_ttl}"
   type = "MX"

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@
  *
  * $ terraform import module.mailer.aws_route53_zone.this[0] <your_route53_zone_id>
  *
- * (The `[0]` is needed becauser it is a "conditional resource" and you must refer to the 'count'
+ * (The `[0]` is needed because it is a "conditional resource" and you must refer to the 'count'
  *  index when importing, which is always [0])
  *
  * where the 'mailer' portion is the name you choose:

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,8 @@ resource "mailgun_domain" "this" {
 }
 
 resource "aws_route53_zone" "this" {
+  # If zone_id is its default (0) then dont create a zone
+  count = "${var.zone_id == "0" ? 1 : 0}"
   # This hack deals with https://github.com/hashicorp/terraform/issues/8511
   name          = "${element( split("","${var.domain}"), "${ length("${var.domain}") -1 }") == "." ? var.domain : "${var.domain}."}"
   comment       = "Zone managed by terraform with mailgun mail and created by github.com/samstav/terraform-mailgun-aws"

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,11 +7,10 @@
  */
 
 output "zone_id" {
-  value = "${aws_route53_zone.this.zone_id}"
+  value = "${data.aws_route53_zone.selected.zone_id}"
 }
-
 
 # Be sure to check this output and set using the UpdateDomainNameservers API
 output "name_servers" {
-  value = "${aws_route53_zone.this.name_servers}"
+  value = "${data.aws_route53_zone.selected.name_servers}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,11 @@ variable "mailgun_set_mx_for_inbound" {
   description = "Affects terraform-mailgun-aws module behavior. Set to false or 0 to prevent this module from setting mailgun.org MX records on your Route53 Hosted Zone. See more information about how terraform handles booleans here: https://www.terraform.io/docs/configuration/variables.html"
 }
 
+variable "zone_id" {
+  default = 0
+  description = "You probbaly want to set this variable if 1) You are using an existing Route53 Zone 2) You don't want to delete and recreate that route53 zone and/or 3) You don't want to `terraform import` your existing Route53 Zone into this module. (Instructions for that are in the README). If this zone id is set, terrafrom-mailgun-aws will use this existing zone *instead of creating one for you*."
+}
+
 variable "record_ttl" {
   default = 300
   description = "Lifespan of DNS records"

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "mailgun_set_mx_for_inbound" {
 
 variable "zone_id" {
   default = 0
-  description = "You probbaly want to set this variable if 1) You are using an existing Route53 Zone 2) You don't want to delete and recreate that route53 zone and/or 3) You don't want to `terraform import` your existing Route53 Zone into this module. (Instructions for that are in the README). If this zone id is set, terrafrom-mailgun-aws will use this existing zone *instead of creating one for you*."
+  description = "You probaly want to set this variable if 1) You are using an existing Route53 Zone 2) You don't want to delete and recreate that route53 zone and/or 3) You don't want to `terraform import` your existing Route53 Zone into this module. (Instructions for that are in the README). If this zone id is set, terrafrom-mailgun-aws will use this existing zone *instead of creating one for you*."
 }
 
 variable "record_ttl" {


### PR DESCRIPTION
If using an existing Route53 Zone, you must set the `zone_id` terraform variable for this module.
                                                                                                             
Another option is to import your Route53 zone *into* this module, but that is probably not the
"route" you want to go. (see what I did there?) But if you do:

```                                                                     
$ terraform import module.mailer.aws_route53_zone.this[0] <your_route53_zone_id>
```
                                                               
(The `[0]` is needed because it is a "conditional resource" and you must refer to the `count`
 index when importing, which is always `0`)
                                                                                                             
where the 'mailer' portion is the name you choose:

```hcl                                                                   
module "mailer" {
  source = "github.com/samstav/terraform-mailgun-aws"
}
```
                                                                            
In *either* case, you can refer to your zone id like this:

```hcl        
  "${module.mailer.zone_id}"
```
                                                                                                       
Since `zone_id` is also an output variable from the terraform-mailgun-aws module.                            

## TODO

- [x] Update README
- [ ] Cut a new release

--------------

Fixes #7 